### PR TITLE
removing space from right side of top menu bar by removing versioning

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -80,15 +80,15 @@ params:
 
   # Menu title if your navbar has a versions selector to access old versions of your site.
   # This menu appears only if you have at least one [params.versions] set.
-  version_menu: Versions
-  versions:
-    latest: v2
-    all:
-      - v2
-      - v1
-    deprecation_warning: |-
-      the documentation is no longer actively maintained.
-        The page that you are viewing is the last archived version.
+  # version_menu: Versions
+  # versions:
+    # latest: v2
+    # all:
+      # - v2
+      # - v1
+    # deprecation_warning: |-
+      # the documentation is no longer actively maintained.
+      # The page that you are viewing is the last archived version.
 
   # User interface configuration
   ui:

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -19,18 +19,6 @@ title: Notary Project
   The Notary project comprises a server and a client for running and interacting
 with trusted collections.
 </h2>
-<div class="mt-5 mx-auto">
-  <!--
-  <a class="btn btn-lg btn-secondary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/">
-    Learn more
-  </a>
-  -->
-  <!--
-  <a class="btn btn-lg btn-primary mr-3 mb-4" href="/docs/{{< param versions.latest >}}/quickstart">
-    Quickstart<i class="fas fa-arrow-alt-circle-right ml-2"></i>
-  </a>
-  -->
-</div>
 {{< /blocks/cover >}}
 
 {{% blocks/lead color="white" %}}


### PR DESCRIPTION
Since we don't need versioning yet, this PR removes the space that the versioning menu item takes up on the right side of the top menu bar by commenting out the versioning info in the config file.

This PR also removes some unused code in the main index file.

Deploy preview: https://deploy-preview-60--notarydev.netlify.app/