### PR TITLE
Updating README with cloud IDE info

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,9 @@
 # Commands to start on workspace startup
 tasks:
   - name: Dev Server
-    init: npm install --lts
+    init: |
+      nvm install --lts
+      npm install
     command: npm run serve
 # Ports to expose on workspace startup
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 # Commands to start on workspace startup
 tasks:
   - name: Dev Server
-    init: npm install
+    init: npm install --lts
     command: npm run serve
 # Ports to expose on workspace startup
 ports:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ The [notaryproject.dev][] website, built using [Hugo][] and hosted on [Netlify][
 
 ## Build prerequisites
 
-### Local
+### Cloud build
+
+Visit [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
+
+### Local build
 
 To build and serve the site, you'll need the latest [LTS release][] of **Node**.
 Like Netlify, we use **[nvm][]**, the Node Version Manager, to install and
@@ -37,10 +41,6 @@ To build and check links, run these commands:
 $ npm run build
 $ npm run check-links
 ```
-
-### Cloud IDE
-
-This repository has been setup to use a [Gitpod.io](https://gitpod.io) remote development environment. The for example, visiting [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) launches an in browser editor and preview environment for the [NotaryProject.dev](https://notaryproject.dev) site.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ $ nvm install --lts
 
 ## Build or serve the site
 
+### Locally
+
 To locally serve the site at [localhost:8888][], run the following command:
 
 ```console
@@ -35,6 +37,10 @@ To build and check links, run these commands:
 $ npm run build
 $ npm run check-links
 ```
+
+### Cloud IDE
+
+This repository has been setup to use a [Gitpod.io](https://gitpod.io) remote development environment. The [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) link has been setup to launch a full blown editor and preview environment for the [NotaryProject.dev](https://notaryproject.dev) site.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,11 @@
 
 The [notaryproject.dev][] website, built using [Hugo][] and hosted on [Netlify][].
 
-## Build prerequisites
-
-### Cloud build
+## Cloud build
 
 Visit [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) to launch a [Gitpod.io](https://gitpod.io) IDE that will allow you to build, preview and make changes to this repo.
 
-### Local build
+## Local build
 
 To build and serve the site, you'll need the latest [LTS release][] of **Node**.
 Like Netlify, we use **[nvm][]**, the Node Version Manager, to install and
@@ -18,7 +16,7 @@ manage Node versions:
 $ nvm install --lts
 ```
 
-#### Setup
+### Setup
 
  1. Clone this repo.
  2. From a terminal window, change to the cloned repo directory.
@@ -27,7 +25,7 @@ $ nvm install --lts
     $ npm install
     ```
 
-#### Build or serve the site
+### Build or serve the site
 
 To locally serve the site at [localhost:8888][], run the following command:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The [notaryproject.dev][] website, built using [Hugo][] and hosted on [Netlify][
 
 ## Build prerequisites
 
+### Local
+
 To build and serve the site, you'll need the latest [LTS release][] of **Node**.
 Like Netlify, we use **[nvm][]**, the Node Version Manager, to install and
 manage Node versions:
@@ -12,7 +14,7 @@ manage Node versions:
 $ nvm install --lts
 ```
 
-## Setup
+#### Setup
 
  1. Clone this repo.
  2. From a terminal window, change to the cloned repo directory.
@@ -21,9 +23,7 @@ $ nvm install --lts
     $ npm install
     ```
 
-## Build or serve the site
-
-### Locally
+#### Build or serve the site
 
 To locally serve the site at [localhost:8888][], run the following command:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npm run check-links
 
 ### Cloud IDE
 
-This repository has been setup to use a [Gitpod.io](https://gitpod.io) remote development environment. The [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) link has been setup to launch a full blown editor and preview environment for the [NotaryProject.dev](https://notaryproject.dev) site.
+This repository has been setup to use a [Gitpod.io](https://gitpod.io) remote development environment. The for example, visiting [https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev](https://gitpod.io/#https://github.com/notaryproject/notaryproject.dev) launches an in browser editor and preview environment for the [NotaryProject.dev](https://notaryproject.dev) site.
 
 # License
 


### PR DESCRIPTION
I've been working with [gitpod.io](https://gitpod.io) cloud development environments, and have found it very useful, so I thought I'd make it a more official part of this repo.

* Updating README file to include information about available cloud IDE options for development.

Deploy preview: https://github.com/notaryproject/notaryproject.dev/blob/nw-2021-11-10-cloud-ide-description/README.md