### PR TITLE
Update build setup instructions: the repo must be cloned

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ nvm install --lts
 
 ## Setup
 
- 1. Clone or download a copy of this repo.
- 2. From a terminal window, change to the cloned or unzipped repo directory.
+ 1. Clone this repo.
+ 2. From a terminal window, change to the cloned repo directory.
  3. Get NPM packages and git submodules, including the the [Docsy][] theme:
     ```console
     $ npm install


### PR DESCRIPTION
The repo must be cloned because we're using submodules.