### PR TITLE
Updating copyright range in footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -18,7 +18,7 @@
         {{ end }}
       </div>
       <div class="col-12 col-sm-4 text-center py-2 order-sm-2">
-        {{ with .Site.Params.copyright }}<small class="text-white">&copy; 2013-{{ now.Year }} {{ . }}
+        {{ with .Site.Params.copyright }}<small class="text-white">&copy; 2019-{{ now.Year }} {{ . }}
           <!-- {{ T "footer_all_rights_reserved" }} -->
         </small>{{ end }}
         {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank">{{ T "footer_privacy_policy" }}</a></small>{{ end }}


### PR DESCRIPTION
Looks like the oldest content on the site is from 2019. Please comment if this is an incorrect date.

Contributes to #16 
