### PR TITLE
Homepage fix: make rel="alternate" link to RSS

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -155,18 +155,16 @@ params:
     https://github.com/cncf/artwork/raw/master/projects/notary/horizontal/white/notary-horizontal-white.png
 
 mediaTypes:
-  text/netlify:
-    delimiter: ''
+  text/netlify: {}
 
 outputFormats:
   REDIRECTS:
     mediaType: text/netlify
     baseName: _redirects
+    notAlternative: true
 
 outputs:
-  home:
-    - HTML
-    - REDIRECTS
+  home: [HTML, REDIRECTS, RSS]
 
 # Site menu (partial -- also see pages with 'menu' in front matter)
 menu:


### PR DESCRIPTION
The original problem was part of the original site from which this was cloned. For details, see https://github.com/etcd-io/website/issues/437.

The only changes to the generated site files are:

```console
 (cd public && git diff)
diff --git a/index.html b/index.html
```
```diff
index 2858667..99d390c 100644
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta name="generator" content="Hugo 0.83.1" /><link rel="alternate" type="text/netlify" href="https://notaryproject.dev/_redirects">
+<meta name="generator" content="Hugo 0.83.1" /><link rel="alternate" type="application/rss&#43;xml" href="https://notaryproject.dev/index.xml">
 <META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
 <link rel="shortcut icon" href="/favicon.png">
 ```

I noticed this as @nate-double-u and I were discussing config of redirects for another project.