### PR TITLE
adding new GA4 measurement ID to config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,7 @@ contentDir: content/en
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: false
 languageCode: en-us
-# googleAnalytics: UA-00000000-00
+googleAnalytics: G-64X4HRE9R0
 
 # Useful when translating.
 enableMissingTranslationPlaceholders: true


### PR DESCRIPTION
contributes to https://github.com/notaryproject/notaryproject.dev/issues/74

Adding new GA4 measurement ID for Google Analytics.