### PR TITLE
doc: update quick start for rc.1 release

### DIFF
--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -56,7 +56,7 @@ In the above example, the reference to the container image using the digest valu
 
 ## List the signatures associated with the container image
 
-`notation ls`
+Use `notation list` to show any signatures associated with the container image you built and pushed in the previous section.
 
 ```console
 IMAGE=localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -23,7 +23,7 @@ docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.3
 > NOTE:
 >
 > - The [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) must be used for testing purpose only.
->`
+>
 > - Since `v1.0.0-rc.1` release, by default, Notation stores signatures using [OCI Artifact Manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md), which is defined in [OCI Image spec v1.1.0](https://github.com/opencontainers/image-spec/tree/v1.1.0-rc2)). If you choose a different registry, make sure the registry is compatible with OCI Image spec v1.1.0.
 
 ## Add an image to the OCI-compatible registry
@@ -56,7 +56,7 @@ In the above example, the reference to the container image using the digest valu
 
 ## List the signatures associated with the container image
 
-Use `notation list` to show any signatures associated with the container image you built and pushed in the previous section.
+Use `notation ls` to show any signatures associated with the container image you built and pushed in the previous section.
 
 ```console
 IMAGE=localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
@@ -67,26 +67,26 @@ Confirm there are no signatures shown in the output.
 
 ## Generate a test key and self-signed certificate
 
-Use `notation certificate generate-test` to generate a test RSA key for signing artifacts, and a self-signed X.509 test certificate for verifying artifacts.
+Use `notation cert generate-test` to generate a test RSA key for signing artifacts, and a self-signed X.509 test certificate for verifying artifacts.
 
 **IMPORTANT**: Self-signed certificates should be used for development purposes only and should not be used in production environments.
 
 The following command generates a test key and a self-signed X.509 certificate. With the `--default` flag, the test key is set as a default signing key. The self-signed X.509 certificate is added to a named trust store `wabbit-networks.io` of type `ca`.
 
 ```console
-notation certificate generate-test --default "wabbit-networks.io"
+notation cert generate-test --default "wabbit-networks.io"
 ```
 
-Use `notation key list` to confirm the signing key is correctly configured. Key name with a `*` prefix is the default key.
+Use `notation key ls` to confirm the signing key is correctly configured. Key name with a `*` prefix is the default key.
 
 ```console
-notation key list
+notation key ls
 ```
 
-Use `notation certificate list` to confirm the certificate is stored in the trust store.
+Use `notation cert ls` to confirm the certificate is stored in the trust store.
 
 ```console
-notation certificate list
+notation cert ls
 ```
 
 ## Sign the container image
@@ -105,16 +105,16 @@ notation sign --signature-format cose $IMAGE
 
 The generated signature is pushed to the registry and the digest of the container image returned.
 
-Use `notation list` to show the signature associated with the container image.
+Use `notation ls` to show the signature associated with the container image.
 
 ```console
-notation list $IMAGE
+notation ls $IMAGE
 ```
 
 Confirm there is one signature, for example:
 
 ```output
-$ notation list $IMAGE
+$ notation ls $IMAGE
 localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 └── application/vnd.cncf.notary.v2.signature
     └── sha256:ba3a68a28648ba18c51a479145fca60d96b43dc96c6ab22f412c89ac56a9038b
@@ -168,10 +168,6 @@ notation verify $IMAGE
 ```
 
 The digest of the supplied artifact is returned upon successful verification.
-
-## Troubleshooting
-
-If you meet any issues using command `notation sign` or `notation verify`, you can add `--verbose` flag to print out `Info`, `Warning` or `Error` logs, or add `--debug` flag to print out `Debug` logs in addition to those enabled by `--verbose` flag.
 
 ## Cleanup
 

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -14,25 +14,17 @@ Before you begin, you need:
 
 ## Create an OCI-compatible registry
 
-Create and run an OCI-compatible registry on your development computer using Docker and the [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) container image. The following command creates a registry that is accessible at `localhost:5000`.
+Create and run an OCI-compatible registry on your development computer using Docker and the [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) container image.The following command creates a registry that is accessible at `localhost:5000`.
 
 ```console
 docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.3
 ```
 
 > NOTE:
-> Since v1.0.0-rc.1 release, by default, Notation stores signatures using OCI artifact Manifest, which is defined in [OCI Image spec v1.1.0](https://github.com/opencontainers/image-spec/tree/v1.1.0-rc2)). If you choose a different registry, make sure the registry is OCI Image spec v1.1.0 compliant.
-
-### Building OCI-compatible registry image from source
-
-In some cases, such as if your development computer is running an Apple silicon processor, you can download the source of the image for the OCI-compatible registry. The following example clones the repository, builds the image using `docker buildx`, and creates a registry that is available at `localhost:5000`.
-
-```console
-git clone https://github.com/oras-project/distribution.git
-cd distribution
-docker buildx build -t oras-project/registry:v1.0.0-rc.3 . 
-docker run -d -p 5000:5000 oras-project/registry:v1.0.0-rc.3
-```
+>
+> - The [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) must be used for testing purpose only.
+>`
+> - Since `v1.0.0-rc.1` release, by default, Notation stores signatures using [OCI Artifact Manifest](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md), which is defined in [OCI Image spec v1.1.0](https://github.com/opencontainers/image-spec/tree/v1.1.0-rc2)). If you choose a different registry, make sure the registry is compatible with OCI Image spec v1.1.0.
 
 ## Add an image to the OCI-compatible registry
 
@@ -60,7 +52,7 @@ v1: digest: sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff5
 In the above example, the reference to the container image using the digest value is `localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a`.
 
 > Note：
-> If you use a tag value to sign an image, `notation` will determine the digest value of the current image associated and will use that digest to sign. Tags can be used to reference the container image.
+> Notation resolves the tag to the digest before signing if a tag is used to identify the container image.
 
 ## List the signatures associated with the container image
 

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -17,8 +17,11 @@ Before you begin, you need:
 Create and run an OCI-compatible registry on your development computer using Docker and the [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) container image. The following command creates a registry that is accessible at `localhost:5000`.
 
 ```console
-docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.2
+docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.3
 ```
+
+> NOTE:
+> Since v1.0.0-rc.1 release, by default, Notation stores signatures using OCI artifact Manifest, which is defined in [OCI Image spec v1.1.0](https://github.com/opencontainers/image-spec/tree/v1.1.0-rc2)). If you choose a different registry, make sure the registry is OCI Image spec v1.1.0 compliant.
 
 ## Add an image to the OCI-compatible registry
 
@@ -29,19 +32,36 @@ docker build -t localhost:5000/net-monitor:v1 https://github.com/wabbit-networks
 docker push localhost:5000/net-monitor:v1
 ```
 
+Tags are mutable and a tag reference can point to a different container image than the one signed. Find out the digest value from the output of `docker push` command.
+
+An example output of `docker push`:
+
+```output
+The push refers to repository [localhost:5000/net-monitor]
+2556c54bfdf3: Pushed
+fb6ca4f9c8d3: Pushed
+ded7a220bb05: Pushed
+v1: digest: sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a size: 942
+```
+
+Use digest to identify the container image as `localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a`.
+
+> Note：
+> Tags can be used to reference the container image. In this example, you can use tag `v1` for reference. Notation commands will resolve the tag `v1` to digest `sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a` first. By validating the digest, you can make sure it is the right container image to reference.
+
 ## List the signatures associated with the container image
 
 Use `notation list` to show any signatures associated with the container image you built and pushed in the previous section.
 
 ```console
-notation list $IMAGE
+notation list localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 ```
 
 Confirm there are no signatures shown in the output.
 
 ## Generate a test key and self-signed certificate
 
-Use `notation cert generate-test` to generate a test RSA key for signing artifacts, and a self-signed X.509 test certificate for verifying artifacts.
+Use `notation certificate generate-test` to generate a test RSA key for signing artifacts, and a self-signed X.509 test certificate for verifying artifacts.
 
 **IMPORTANT**: Self-signed certificates should be used for development purposes only and should not be used in production environments.
 
@@ -68,13 +88,13 @@ notation certificate list
 Use `notation sign` to sign the container image.
 
 ```console
-notation sign $IMAGE
+notation sign localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 ```
 
 By default, the signature format is `JWS`. Use `--signature-format` to use [COSE](https://datatracker.ietf.org/doc/html/rfc8152/) signature format.
 
 ```console
-notation sign --signature-format cose $IMAGE
+notation sign --signature-format cose localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 ```
 
 The generated signature is pushed to the registry and the digest of the container image returned.
@@ -82,13 +102,13 @@ The generated signature is pushed to the registry and the digest of the containe
 Use `notation list` to show the signature associated with the container image.
 
 ```console
-notation list $IMAGE
+notation list localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 ```
 
 Confirm there is one signature, for example:
 
 ```output
-$ notation list $IMAGE
+$ notation list localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 └── application/vnd.cncf.notary.v2.signature
     └── sha256:ba3a68a28648ba18c51a479145fca60d96b43dc96c6ab22f412c89ac56a9038b
@@ -96,11 +116,11 @@ localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda27
 
 ## Create a trust policy
 
-To verify the container image, configure the trust policy to specify trusted identities that sign the artifacts, and level of signature verification to use. For more detaisl, see [trust policy spec]({{< ref "/docs/concepts/trust-store-trust-policy-specification#trust-policy" >}}).
+To verify the container image, configure the trust policy to specify trusted identities that sign the artifacts, and level of signature verification to use. For more details, see [trust policy spec]({{< ref "/docs/concepts/trust-store-trust-policy-specification#trust-policy" >}}).
 
 Create a `trustpolicy.json` with the following trust policy in the notation configuration directory.
 
-**NOTE:** For Linux, the notation configuration directory is `$HOME/.config/notation/`. For macOS, the notation configuration directory is `$HOME/Library/Application Support/notation/`. For Windows, the notation configuration folder is `C:\Users\<username>\AppData\Roaming\notation\`.
+**NOTE:** For Linux, the notation configuration directory is `${HOME}/.config/notation/`. For macOS, the notation configuration directory is `${HOME}/Library/Application Support/notation/`. For Windows, the notation configuration folder is `%USERPROFILE%\AppData\Roaming\notation\`.
 
 ```json
 {
@@ -123,7 +143,7 @@ Create a `trustpolicy.json` with the following trust policy in the notation conf
 
 The above JSON creates a trust policy named `wabbit-networks-images`. The policy has `registryScopes` set to `*`, which applies the policy to all the artifacts of any registry. The `signatureVerification` is set to `strict`, which checks all validations and any failure will fail the signature verification. This policy uses the `wabbit-networks.io` trust store of type `ca` which was created in the previous step. For more details on trust policies, see [trust policy spec]({{< ref "/docs/concepts/trust-store-trust-policy-specification#trust-policy-properties" >}}).
 
-To enable trust policy for specific registries, set the `registryScopes` to those specific registries. For example:
+To enable trust policy for specific repositories, set the `registryScopes` to those specific repositories. For example:
 
 ```json
 registryScopes": [ 
@@ -135,10 +155,10 @@ registryScopes": [
 
 ## Verify the container image
 
-Use `notification verify` to verify signatures associated with the container image.
+Use `notation verify` to verify signatures associated with the container image.
 
 ```console
-notation verify $IMAGE
+notation verify localhost:5000/net-monitor@sha256:073b75987e95b89f187a89809f08a32033972bb63cda279db8a9ca16b7ff555a
 ```
 
 The digest of the supplied artifact is returned upon successful verification.
@@ -152,16 +172,16 @@ To remove local keys, self-signed certificates, and notation configurations, rem
 For linux:
 
 ```console
-rm -r $HOME/.config/notation/
+rm -r ${HOME}/.config/notation/
 ```
 
 For macOS:
 
 ```console
-rm -r $HOME/Library/Application Support/notation/
+rm -r ${HOME}/Library/Application Support/notation/
 ```
 
-For Windows, delete the directory `C:\Users\<username>\AppData\Roaming\notation\`
+For Windows, delete the directory `%USERPROFILE%\AppData\Roaming\notation\`
 
 ### Remove the registry
 

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -171,9 +171,7 @@ The digest of the supplied artifact is returned upon successful verification.
 
 ## Troubleshooting
 
-Use `--verbose` flag for `notation sign` or `notation verify` command to print out `Info`, `Warning` or `Error` logs.
-
-Use `--debug` flag for `notation sign` or `notation verify` command to print out `Debug` logs in addition to those enabled by `--verbose` flag.
+If you meet any issues using command `notation sign` or `notation verify`, you can add `--verbose` flag to print out `Info`, `Warning` or `Error` logs, or add `--debug` flag to print out `Debug` logs in addition to those enabled by `--verbose` flag.
 
 ## Cleanup
 

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -14,7 +14,7 @@ Before you begin, you need:
 
 ## Create an OCI-compatible registry
 
-Create and run an OCI-compatible registry on your development computer using Docker and the [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) container image.The following command creates a registry that is accessible at `localhost:5000`.
+Create and run an OCI-compatible registry on your development computer using Docker and the [oras-project/registry](https://github.com/oras-project/distribution/pkgs/container/registry) container image. The following command creates a registry that is accessible at `localhost:5000`.
 
 ```console
 docker run -d -p 5000:5000 ghcr.io/oras-project/registry:v1.0.0-rc.3


### PR DESCRIPTION
- Update distribution version for OCI artifact support
- Update directory path for different OS
- Add notes for tag2digest, and use digest instead of tag to identify container image
- Add a note for signature format using OCI Artifact manifest.

Signed-off-by: Yi Zha <yizha1@microsoft.com>