### PR TITLE
Revert #86: drop GA4 ID from config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,7 +11,6 @@ contentDir: content/en
 defaultContentLanguage: en
 defaultContentLanguageInSubdir: false
 languageCode: en-us
-googleAnalytics: G-64X4HRE9R0
 
 # Useful when translating.
 enableMissingTranslationPlaceholders: true


### PR DESCRIPTION
- Followup to #74
- Effectively reverts #86

/cc @nate-double-u 