### PR TITLE
Add Samir Kakkar as NotaryProject.dev maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @iamsamirzon

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Samir Kakkar <iamsamir@amazon.com> (@iamsamirzon)


### PR DESCRIPTION
Add Samir Kakkar as a seed maintainer of NotaryProject.dev based on their activity and as per - https://github.com/notaryproject/notaryproject.dev/issues/127

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>