### PR TITLE
Add Feynman Zhou as notaryproject.dev maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FeynmanZhou

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Feynman Zhou <feynmanzhou@microsoft.com> (@FeynmanZhou)


### PR DESCRIPTION
Add Feynman Zhou (@FeynmanZhou) as a seed maintainer of NotaryProject.dev based on [their](https://github.com/notaryproject/notaryproject.dev/commits?author=feynmanzhou) activity and as per - https://github.com/notaryproject/notaryproject.dev/issues/127

Signed-off-by: Yi Zha <yizha1@microsoft.com>