### PR TITLE
Add Toddy Mladenov as notaryproject.dev maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @toddysm

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Toddy Mladenov <toddysm@gmail.com> (@toddysm)


### PR DESCRIPTION
Add Toddy Mladenov (@toddysm) as a seed maintainer of NotaryProject.dev based on their activity and as per - https://github.com/notaryproject/notaryproject.dev/issues/127

Signed-off-by: Yi Zha <yizha1@microsoft.com>