### PR TITLE
Added float copy button for the command lines #193

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,7 +73,7 @@ params:
   offlineSearch: false
 
   # Enable syntax highlighting and copy buttons on code blocks with Prism
-  prism_syntax_highlighting: false
+  prism_syntax_highlighting: true
 
   # Versions
 


### PR DESCRIPTION
**Description**

This PR addresses issue [#193 ](https://github.com/notaryproject/notaryproject.dev/issues/193) by adding a floating copy button for command lines in order to improve user experience and make it easier to copy long command lines.

**Screenshot**
![Quickstart_ Sign and validate a container image _ Notary _ Signing and verifying artifacts  Safeguarding the software delivery security from development to deployment  - Google Chrome 5_11_2023 1_22_26 PM (2)](https://github.com/notaryproject/notaryproject.dev/assets/86047367/0ebcee88-b92b-4b2d-a54a-22d8029eb640)

![Quickstart_ Sign and validate a container image _ Notary _ Signing and verifying artifacts  Safeguarding the software delivery security from development to deployment  - Google Chrome 5_11_2023 1_20_57 PM (2)](https://github.com/notaryproject/notaryproject.dev/assets/86047367/ead40f40-064f-4f72-8600-efb4bed96952)

