### PR TITLE
Added float copy button for the command lines #193

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -73,7 +73,7 @@ params:
   offlineSearch: false
 
   # Enable syntax highlighting and copy buttons on code blocks with Prism
-  prism_syntax_highlighting: false
+  prism_syntax_highlighting: true
 
   # Versions
 

--- a/content/en/docs/cli-reference/notation.md
+++ b/content/en/docs/cli-reference/notation.md
@@ -5,6 +5,6 @@ Notation - a tool to sign and verify artifacts
 
 ### Options
 
-```
+```console
   -h, --help   help for notation
 ```

--- a/content/en/docs/cli-reference/notation_certificate.md
+++ b/content/en/docs/cli-reference/notation_certificate.md
@@ -10,6 +10,6 @@ Manage certificates in trust store for signature verification.
 
 ### Options
 
-```
+```console
   -h, --help   help for certificate
 ```

--- a/content/en/docs/cli-reference/notation_certificate_add.md
+++ b/content/en/docs/cli-reference/notation_certificate_add.md
@@ -10,18 +10,18 @@ Add certificates to the trust store
 
 Example - Add a certificate to the "ca" type of a named store "acme-rockets":
 
-```
+```shell
 notation cert add --type ca --store acme-rockets acme-rockets.crt
 ```
 
 Example - Add a certificate to the "signingAuthority" type of a named store "wabbit-networks":
 
-```
+```shell
 notation cert add --type signingAuthority --store wabbit-networks wabbit-networks.pem
 ```
 
 General usage:
-```
+```shell
 notation certificate add --type <type> --store <name> [flags] <cert_path>...
 ```
 

--- a/content/en/docs/cli-reference/notation_certificate_delete.md
+++ b/content/en/docs/cli-reference/notation_certificate_delete.md
@@ -10,24 +10,24 @@ Delete certificates from the trust store
 
 Example - Delete all certificates with "ca" type from the trust store "acme-rockets":
 
-```  
+```shell
 notation cert delete --type ca --store acme-rockets --all
 ```
 
 Example - Delete certificate "cert1.pem" with "signingAuthority" type from trust store wabbit-networks:
 
-```
+```shell
 notation cert delete --type signingAuthority --store wabbit-networks cert1.pem
 ```
 
 Example - Delete all certificates with "ca" type from the trust store "acme-rockets", without prompt for confirmation:
 
-```
+```shell
 notation cert delete --type ca --store acme-rockets -y --all 
 ```
 
 General usage:
-```
+```shell
 notation certificate delete --type <type> --store <name> [flags] (--all | <cert_fileName>)
 ```
 

--- a/content/en/docs/cli-reference/notation_certificate_generate-test.md
+++ b/content/en/docs/cli-reference/notation_certificate_generate-test.md
@@ -9,17 +9,17 @@ Generate a test RSA key and a corresponding self-signed certificate.
 Generate a test RSA key and a corresponding self-signed certificate
 
 Example - Generate a test RSA key and a corresponding self-signed certificate named "wabbit-networks.io":
-```  
+```shell
 notation cert generate-test "wabbit-networks.io"
 ```
 
 Example - Generate a test RSA key and a corresponding self-signed certificate, set RSA key as a default signing key:
-```
+```shell
 notation cert generate-test --default "wabbit-networks.io"
 ```
 
 General usage:
-```
+```shell
 notation certificate generate-test [flags] <common_name>
 ```
 

--- a/content/en/docs/cli-reference/notation_certificate_list.md
+++ b/content/en/docs/cli-reference/notation_certificate_list.md
@@ -9,27 +9,27 @@ List certificates in the trust store.
 List certificates in the trust store
 
 Example - List all certificate files stored in the trust store
-```  
+```shell
 notation cert ls
 ```
 
 Example - List all certificate files of trust store "acme-rockets"
-```
+```shell
 notation cert ls --store "acme-rockets"
 ```
 
 Example - List all certificate files from trust store of type "ca"
-```  
+```shell
 notation cert ls --type ca
 ```
 
 Example - List all certificate files from trust store "wabbit-networks" of type "signingAuthority"
-```
+```shell
 notation cert ls --type signingAuthority --store "wabbit-networks"
 ```
 
 General usage:
-```
+```shell
 notation certificate list [flags]
 ```
 

--- a/content/en/docs/cli-reference/notation_certificate_show.md
+++ b/content/en/docs/cli-reference/notation_certificate_show.md
@@ -9,17 +9,17 @@ Show certificate details given trust store type, named store, and certificate fi
 Show certificate details of given trust store name, trust store type, and certificate file name. If the certificate file contains multiple certificates, then all certificates are displayed
 
 Example - Show details of certificate "cert1.pem" with type "ca" from trust store "acme-rockets":
-```
+```shell
 notation cert show --type ca --store acme-rockets cert1.pem
 ```
 
 Example - Show details of certificate "cert2.pem" with type "signingAuthority" from trust store "wabbit-networks":
-```  
+```shell
 notation cert show --type signingAuthority --store wabbit-networks cert2.pem
 ```
 
 General usage:
-```
+```shell
 notation certificate show --type <type> --store <name> [flags] <cert_fileName>
 ```
 

--- a/content/en/docs/cli-reference/notation_inspect.md
+++ b/content/en/docs/cli-reference/notation_inspect.md
@@ -9,22 +9,22 @@ Inspect all signatures associated with the signed artifact
 Inspect all signatures associated with the signed artifact.
 
 Example - Inspect signatures on an OCI artifact identified by a digest:
-```
+```shell
 notation inspect <registry>/<repository>@<digest>
 ```
 
 Example - Inspect signatures on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-```
+```shell
 notation inspect <registry>/<repository>:<tag>
 ```
 
 Example - Inspect signatures on an OCI artifact identified by a digest and output as json:
-```
+```shell
 notation inspect --output json <registry>/<repository>@<digest>
 ```
 
 General usage:
-```
+```shell
 notation inspect [reference] [flags]
 ```
 

--- a/content/en/docs/cli-reference/notation_key.md
+++ b/content/en/docs/cli-reference/notation_key.md
@@ -9,27 +9,27 @@ Manage keys used for signing
 Manage keys used for signing
 
 Example - Add a key to signing key list:
-```  
+```shell
 notation key add --plugin <plugin_name> --id <key_id> <key_name>
 ```
 
 Example - List keys used for signing:
-```
+```shell
 notation key ls
 ```
 
 Example - Update the default signing key:
-```
+```shell
 notation key set --default <key_name>
 ```
 
 Example - Delete the key from signing key list:
-```
+```shell
 notation key delete <key_name>...
 ```
 
 ### Options
 
-```
+```shell
   -h, --help   help for key
 ```

--- a/content/en/docs/cli-reference/notation_key_add.md
+++ b/content/en/docs/cli-reference/notation_key_add.md
@@ -5,7 +5,7 @@ title: notation key add
 Add key to signing key list
 
 General usage:
-```
+```shell
 notation key add --plugin <plugin_name> [flags] <key_name>
 ```
 

--- a/content/en/docs/cli-reference/notation_key_delete.md
+++ b/content/en/docs/cli-reference/notation_key_delete.md
@@ -5,7 +5,7 @@ title: notation key delete
 Delete key from signing key list
 
 General usage:
-```
+```shell
 notation key delete [flags] <key_name>...
 ```
 

--- a/content/en/docs/cli-reference/notation_key_list.md
+++ b/content/en/docs/cli-reference/notation_key_list.md
@@ -5,12 +5,12 @@ title: notation key list
 List keys used for signing
 
 General usage:
-```
+```shell
 notation key list [flags]
 ```
 
 ### Options
 
-```
+```shell
   -h, --help   help for list
 ```

--- a/content/en/docs/cli-reference/notation_key_update.md
+++ b/content/en/docs/cli-reference/notation_key_update.md
@@ -4,7 +4,7 @@ title: notation key update
 
 Update key in signing key list
 
-```
+```shell
 notation key update [flags] <key_name>
 ```
 

--- a/content/en/docs/cli-reference/notation_list.md
+++ b/content/en/docs/cli-reference/notation_list.md
@@ -9,7 +9,7 @@ List signatures of the signed artifact
 List all the signatures associated with signed artifact
 
 General usage:
-```
+```shell
 notation list [flags] <reference>
 ```
 

--- a/content/en/docs/cli-reference/notation_login.md
+++ b/content/en/docs/cli-reference/notation_login.md
@@ -9,17 +9,17 @@ Login to registry
 Log in to an OCI registry
 
 Example - Login with provided username and password:
-```
+```shell
 notation login -u <user> -p <password> registry.example.com
 ```
 
 Example - Login using $NOTATION_USERNAME $NOTATION_PASSWORD variables:
-```	
+```shell
 notation login registry.example.com
 ```
 
 General usage:
-```
+```shell
 notation login [flags] <server>
 ```
 

--- a/content/en/docs/cli-reference/notation_logout.md
+++ b/content/en/docs/cli-reference/notation_logout.md
@@ -5,7 +5,7 @@ title: notation logout
 Log out from the logged in registries
 
 General usage:
-```
+```shell
 notation logout [flags] <server>
 ```
 

--- a/content/en/docs/cli-reference/notation_plugin.md
+++ b/content/en/docs/cli-reference/notation_plugin.md
@@ -6,7 +6,7 @@ Manage plugins
 
 ### Options
 
-```
+```console
   -h, --help   help for plugin
 ```
 

--- a/content/en/docs/cli-reference/notation_plugin_list.md
+++ b/content/en/docs/cli-reference/notation_plugin_list.md
@@ -12,12 +12,12 @@ Example - List installed Notation plugins:
   notation plugin ls
 
 General usage:
-```
+```shell
 notation plugin list [flags]
 ```
 
 ### Options
 
-```
+```console
   -h, --help   help for list
 ```

--- a/content/en/docs/cli-reference/notation_policy.md
+++ b/content/en/docs/cli-reference/notation_policy.md
@@ -10,7 +10,7 @@ Manage trust policy configuration for signature verification.
 
 ### Options
 
-```
+```console
   -h, --help   help for policy
 ```
 

--- a/content/en/docs/cli-reference/notation_policy_import.md
+++ b/content/en/docs/cli-reference/notation_policy_import.md
@@ -11,18 +11,18 @@ Import trust policy configuration from a JSON file.
 ** This command is in preview and under development. **
 
 Example - Import trust policy configuration from a file:
-```
+```shell
 notation policy import my_policy.json
 ```
 
 General usage:
-```
+```shell
 notation policy import [flags] <file_path>
 ```
 
 ### Options
 
-```
+```shell
       --force   override the existing trust policy configuration, never prompt
   -h, --help    help for import
 ```

--- a/content/en/docs/cli-reference/notation_policy_show.md
+++ b/content/en/docs/cli-reference/notation_policy_show.md
@@ -11,22 +11,22 @@ Show trust policy configuration.
 ** This command is in preview and under development. **
 
 Example - Show current trust policy configuration:
-```
+```shell
 notation policy show
 ```
 
 Example - Save current trust policy configuration to a file:
-```
+```shell
 notation policy show > my_policy.json
 ```
 
 General usage:
-```
+```shell
 notation policy show [flags]
 ```
 
 ### Options
 
-```
+```shell
   -h, --help   help for show
 ```

--- a/content/en/docs/cli-reference/notation_sign.md
+++ b/content/en/docs/cli-reference/notation_sign.md
@@ -11,52 +11,52 @@ Sign artifacts
 Note: a signing key must be specified. This can be done temporarily by specifying a key ID, or a new key can be configured using the command "notation key add"
 
 Example - Sign an OCI artifact using the default signing key, with the default JWS envelope, and use OCI image manifest to store the signature:
-```
+```shell
 notation sign <registry>/<repository>@<digest>
 ```
 
 Example - Sign an OCI artifact using the default signing key, with the COSE envelope:
-```
+```shell
 notation sign --signature-format cose <registry>/<repository>@<digest> 
 ```
 
 Example - Sign an OCI artifact with a specified plugin and signing key stored in KMS 
-```
+```shell
 notation sign --plugin <plugin_name> --id <remote_key_id> <registry>/<repository>@<digest>
 ```
 
 Example - Sign an OCI artifact using a specified key
-```
+```shell
 notation sign --key <key_name> <registry>/<repository>@<digest>
 ```
 
 Example - Sign an OCI artifact identified by a tag (Notation will resolve tag to digest)
-```
+```shell
 notation sign <registry>/<repository>:<tag>
 ```
 
 Example - Sign an OCI artifact stored in a registry and specify the signature expiry duration, for example 24 hours
-```
+```shell
 notation sign --expiry 24h <registry>/<repository>@<digest>
 ```
 
 Example - [Experimental] Sign an OCI artifact referenced in an OCI layout
-```
+```shell
 notation sign --oci-layout "<oci_layout_path>@<digest>"
 ```
 
 Example - [Experimental] Sign an OCI artifact identified by a tag and referenced in an OCI layout
-```
+```shell
 notation sign --oci-layout "<oci_layout_path>:<tag>"
 ```
 
 Example - [Experimental] Sign an OCI artifact and use OCI artifact manifest to store the signature:
-```
+```shell
 notation sign --signature-manifest artifact <registry>/<repository>@<digest>
 ```
 
 General usage:
-```
+```shell
 notation sign [flags] <reference>
 ```
 

--- a/content/en/docs/cli-reference/notation_verify.md
+++ b/content/en/docs/cli-reference/notation_verify.md
@@ -11,27 +11,27 @@ Verify OCI artifacts
 Prerequisite: added a certificate into trust store and created a trust policy.
 
 Example - Verify a signature on an OCI artifact identified by a digest:
-```
+```shell
 notation verify <registry>/<repository>@<digest>
 ```
 
 Example - Verify a signature on an OCI artifact identified by a tag  (Notation will resolve tag to digest):
-```
+```shell
 notation verify <registry>/<repository>:<tag>
 ```
 
 Example - [Experimental] Verify a signature on an OCI artifact referenced in an OCI layout using trust policy statement specified by scope.
-```
+```shell
 notation verify --oci-layout <registry>/<repository>@<digest> --scope <trust_policy_scope>
 ```
 
 Example - [Experimental] Verify a signature on an OCI artifact identified by a tag and referenced in an OCI layout using trust policy statement specified by scope.
-```  
+```shell
 notation verify --oci-layout <registry>/<repository>:<tag> --scope <trust_policy_scope>
 ```
 
 General usage:
-```
+```shell
 notation verify [reference] [flags]
 ```
 

--- a/content/en/docs/cli-reference/notation_version.md
+++ b/content/en/docs/cli-reference/notation_version.md
@@ -5,12 +5,12 @@ title: notation version
 Show the notation version information
 
 General usage:
-```
+```console
 notation version [flags]
 ```
 
 ### Options
 
-```
+```console
   -h, --help   help for version
 ```

--- a/content/en/docs/concepts/directory-structure.md
+++ b/content/en/docs/concepts/directory-structure.md
@@ -73,13 +73,13 @@ The overall directory structure for `notation` is summarized as follows.
 
 The path for the `notation` binary is as follows.
 
-```
+```console
 {NOTATION_BIN}/notation
 ```
 
 On Windows, the `.exe` extension is required for executables.
 
-```
+```console
 {NOTATION_BIN}/notation.exe
 ```
 
@@ -87,13 +87,13 @@ On Windows, the `.exe` extension is required for executables.
 
 [Plugins][Plugin] are binaries not meant to be executed directly by users' shell or scripts. The path of a plugin follows the pattern below.
 
-```
+```console
 {NOTATION_LIBEXEC}/plugins/{plugin-name}/notation-{plugin-name}
 ```
 
 On Windows, the `.exe` extension is required for executables.
 
-```
+```console
 {NOTATION_LIBEXEC}/plugins/{plugin-name}/notation-{plugin-name}.exe
 ```
 
@@ -101,7 +101,7 @@ On Windows, the `.exe` extension is required for executables.
 
 The path of the general configuration file of the `notation` CLI is as follows.
 
-```
+```console
 {NOTATION_CONFIG}/config.json
 ```
 
@@ -109,7 +109,7 @@ The path of the general configuration file of the `notation` CLI is as follows.
 
 The path of a certificate file in a [Trust Store][TS] follows the pattern of below
 
-```
+```console
 {NOTATION_CONFIG}/truststore/{trust-store-type}/{named-store}/{cert-file}
 ```
 
@@ -117,7 +117,7 @@ The path of a certificate file in a [Trust Store][TS] follows the pattern of bel
 
 The path of the [Trust Policy][TP] file is as follows.
 
-```
+```console
 {NOTATION_CONFIG}/trustpolicy.json
 ```
 
@@ -125,7 +125,7 @@ The path of the [Trust Policy][TP] file is as follows.
 
 Developers sign artifacts using local private keys with associated certificate chain. The signing key information is tracked in a JSON file at:
 
-```
+```console
 {NOTATION_CONFIG}/signingkeys.json
 ```
 
@@ -133,7 +133,7 @@ The signing key store is user-specific. Developers SHOULD consider safe places t
 
 For testing purpose, the following directory structure is suggested.
 
-```
+```console
 {NOTATION_CONFIG}/localkeys/{key-name}.crt
 {NOTATION_CONFIG}/localkeys/{key-name}.pem
 ```

--- a/content/en/docs/how-to/oci-image-layout.md
+++ b/content/en/docs/how-to/oci-image-layout.md
@@ -1,0 +1,125 @@
+---
+title: Manage images as OCI image layout
+description: Build, sign, push, and verify images as OCI image layout
+weight: 10
+---
+
+OCI image layout is a directory structure that contains files and folders that refer to an OCI image. OCI image layout is defined in [OCI image spec](https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/image-layout.md).
+
+When you sign an image after it is pushed to a registry, it is possible that you are not signing the correct image. You also may not be certain that the image hasn't been altered. Using OCI image layout, you can sign images on local disk before pushing them to the remote registry. Signing an image before you push it a registry provides helps ensure you are signing the correct image, and consumers of that image can verify that same image.
+
+{{% alert title="Important" color="primary" %}}
+This feature is experimental. It is not recommended for production use.
+{{% /alert %}}
+
+
+## Create OCI image layout for an image
+
+Use `docker buildx build` with the `--output type=oci` flag to create an OCI image layout for an image.
+
+For example, create a Dockerfile with the following content:
+
+```dockerfile
+FROM alpine
+CMD echo 'hello world!'
+```
+
+Use `docker buildx create` and `docker buildx build` to create an OCI image layout for the image defined in the Dockerfile.
+
+```console
+docker buildx create --use
+docker buildx build . -f Dockerfile -o type=oci,dest=hello-world.tar -t hello-world:v1
+```
+
+The above example sets `output=hello-world.tar` to save the OCI image layout as a tar file named `hello-world.tar`. To view the OCI image layout as a directory structure, extract the tar file.
+
+```console
+mkdir hello-world
+tar -xf ./hello-world.tar -C hello-world
+```
+
+{{% alert title="Important" color="primary" %}}
+You must extract the tar file before you can sign an image as an OCI image layout.
+{{% /alert %}}
+
+## Sign an image as an OCI image layout
+
+To sign an existing image as an OCI image layout, enable the `NOTATION_EXPERIMENTAL` environment variable and use the `notation sign` command with the `--oci-layout` flag. The following example enables the `NOTATION_EXPERIMENTAL` environment variable, creates a self-signed certificate, and signs the image `hello-world:v1` as an OCI image layout.
+
+```console
+export NOTATION_EXPERIMENTAL=1
+notation cert generate-test wabbit-networks.io --default
+notation sign --oci-layout ./hello-world:v1
+```
+
+{{% alert title="Note" color="primary" %}}
+Signatures are stored in the same OCI image layout directory, and associated with OCI image.
+{{% /alert %}}
+
+Use `notation list --oci-layout` to list signatures associated with an OCI image layout.
+
+```shell
+notation list --oci-layout ./hello-world:v1
+```
+
+## Verify an image as an OCI image layout
+
+You can verify an image as an OCI image layout using `notation verify --scope` and setting `registryScopes` in your trust policy. For example, the following trust policy has `registryScopes` set to `local/hello-world`:
+
+```json
+{
+ "version": "1.0",
+ "trustPolicies": [
+    {
+         "name": "local-images-policy",
+         "registryScopes": [ "local/hello-world" ],
+         "signatureVerification": {
+             "level" : "strict"
+         },
+         "trustStores": [ "ca:wabbit-networks.io" ],
+         "trustedIdentities": [
+             "*"
+         ]
+     }
+ ]
+}
+```
+
+The following command imports `permissive-trustpolicy.json`:
+
+```console
+notation policy import ./permissive-trustpolicy.json
+```
+
+Use `notation verify` with `--scope` set to the same value you set in your trust policy to verify the image against signatures:
+
+```shell
+notation verify --oci-layout ./hello-world:v1 --scope "local/hello-world"
+```
+
+## Push an OCI image layout to a remote registry
+
+You can push an image to a remote registry as an OCI image layout on local disk using the [oras](https://oras.land/docs/CLI/installation) CLI. 
+
+If you need a remote registry, you can create and run an OCI-compatible registry on your development computer using the [distribution/distribution](https://github.com/distribution/distribution) with the [image deletion](https://docs.docker.com/registry/spec/api/#deleting-an-image) enabled. The following command creates a registry that is accessible at `localhost:5001`.
+
+```console
+docker run -d -p 5001:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true --name registry registry
+```
+
+Use `oras cp` to push the OCI image layout to the remote registry. For example:
+
+```console
+oras cp ./hello-world:v1 --from-oci-layout -r localhost:5001/hello-world:v1
+```
+
+{{% alert title="Important" color="primary" %}}
+You must use the flag `-r` so that the signatures are copied together with the image.
+{{% /alert %}}
+
+Use `notation list` and `notation verify` to list and verify the image signatures. For example:
+
+```console
+notation list localhost:5001/hello-world:v1
+notation verify localhost:5001/hello-world:v1
+```

--- a/static/css/prism.css
+++ b/static/css/prism.css
@@ -1,0 +1,205 @@
+/* PrismJS 1.21.0
+https://prismjs.com/download.html#themes=prism&languages=markup+css+clike+javascript+bash+c+csharp+cpp+go+java+markdown+python+scss+sql+toml+yaml&plugins=toolbar+copy-to-clipboard */
+/**
+ * prism.js default theme for JavaScript, CSS and HTML
+ * Based on dabblet (http://dabblet.com)
+ * @author Lea Verou
+ */
+
+ code[class*="language-"],
+ pre[class*="language-"] {
+     color: black;
+     background: none;
+     text-shadow: 0 1px white;
+     font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+     font-size: 1em;
+     text-align: left;
+     white-space: pre;
+     word-spacing: normal;
+     word-break: normal;
+     word-wrap: normal;
+     line-height: 1.5;
+ 
+     -moz-tab-size: 4;
+     -o-tab-size: 4;
+     tab-size: 4;
+ 
+     -webkit-hyphens: none;
+     -moz-hyphens: none;
+     -ms-hyphens: none;
+     hyphens: none;
+ }
+ 
+ pre[class*="language-"]::-moz-selection, pre[class*="language-"] ::-moz-selection,
+ code[class*="language-"]::-moz-selection, code[class*="language-"] ::-moz-selection {
+     text-shadow: none;
+     background: #b3d4fc;
+ }
+ 
+ pre[class*="language-"]::selection, pre[class*="language-"] ::selection,
+ code[class*="language-"]::selection, code[class*="language-"] ::selection {
+     text-shadow: none;
+     background: #b3d4fc;
+ }
+ 
+ @media print {
+     code[class*="language-"],
+     pre[class*="language-"] {
+         text-shadow: none;
+     }
+ }
+ 
+ /* Code blocks */
+ pre[class*="language-"] {
+     padding: 1em;
+     margin: .5em 0;
+     overflow: auto;
+ }
+ 
+ :not(pre) > code[class*="language-"],
+ pre[class*="language-"] {
+     background: #f5f2f0;
+ }
+ 
+ /* Inline code */
+ :not(pre) > code[class*="language-"] {
+     padding: .1em;
+     border-radius: .3em;
+     white-space: normal;
+ }
+ 
+ .token.comment,
+ .token.prolog,
+ .token.doctype,
+ .token.cdata {
+     color: slategray;
+ }
+ 
+ .token.punctuation {
+     color: #999;
+ }
+ 
+ .token.namespace {
+     opacity: .7;
+ }
+ 
+ .token.property,
+ .token.tag,
+ .token.boolean,
+ .token.number,
+ .token.constant,
+ .token.symbol,
+ .token.deleted {
+     color: #905;
+ }
+ 
+ .token.selector,
+ .token.attr-name,
+ .token.string,
+ .token.char,
+ .token.builtin,
+ .token.inserted {
+     color: #690;
+ }
+ 
+ .token.operator,
+ .token.entity,
+ .token.url,
+ .language-css .token.string,
+ .style .token.string {
+     color: #9a6e3a;
+     /* This background color was intended by the author of this theme. */
+     background: hsla(0, 0%, 100%, .5);
+ }
+ 
+ .token.atrule,
+ .token.attr-value,
+ .token.keyword {
+     color: #07a;
+ }
+ 
+ .token.function,
+ .token.class-name {
+     color: #DD4A68;
+ }
+ 
+ .token.regex,
+ .token.important,
+ .token.variable {
+     color: #e90;
+ }
+ 
+ .token.important,
+ .token.bold {
+     font-weight: bold;
+ }
+ .token.italic {
+     font-style: italic;
+ }
+ 
+ .token.entity {
+     cursor: help;
+ }
+ 
+ div.code-toolbar {
+     position: relative;
+ }
+ 
+ div.code-toolbar > .toolbar {
+     position: absolute;
+     top: -.12em;
+     right: .2em;
+     transition: opacity 0.3s ease-in-out;
+     opacity: 0;
+ }
+ 
+ div.code-toolbar:hover > .toolbar {
+     opacity: 1;
+ }
+ 
+ /* Separate line b/c rules are thrown out if selector is invalid.
+    IE11 and old Edge versions don't support :focus-within. */
+ div.code-toolbar:focus-within > .toolbar {
+     opacity: 1;
+ }
+ 
+ div.code-toolbar > .toolbar .toolbar-item {
+     display: inline-block;
+ }
+ 
+ div.code-toolbar > .toolbar a {
+     cursor: pointer;
+ }
+ 
+ div.code-toolbar > .toolbar button {
+     background: none;
+     border: 0;
+     color: inherit;
+     font: inherit;
+     line-height: normal;
+     overflow: visible;
+     padding: 0;
+ }
+ 
+ div.code-toolbar > .toolbar a,
+ div.code-toolbar > .toolbar button,
+ div.code-toolbar > .toolbar span {
+     color: #bbb;
+     font-size: .9em;
+     padding: 0 .5em;
+     background: #0a1238;
+     box-shadow: 0 2px 0 0 rgba(0,0,0,0.2);
+     border-radius: .5em;
+ }
+ 
+ div.code-toolbar > .toolbar a:hover,
+ div.code-toolbar > .toolbar a:focus,
+ div.code-toolbar > .toolbar button:hover,
+ div.code-toolbar > .toolbar button:focus,
+ div.code-toolbar > .toolbar span:hover,
+ div.code-toolbar > .toolbar span:focus {
+     color: white;
+     text-decoration: none;
+ }
+ 
+ 


### PR DESCRIPTION
**Description**

This PR addresses issue [#193 ](https://github.com/notaryproject/notaryproject.dev/issues/193) by adding a floating copy button for command lines in order to improve user experience and make it easier to copy long command lines.

![Quickstart_ Sign and validate a container image _ Notary _ Signing and verifying artifacts  Safeguarding the software delivery security from development to deployment  - Google Chrome 5_11_2023 11_24_49 PM (2)](https://github.com/notaryproject/notaryproject.dev/assets/86047367/9badca86-c6cc-480f-b8a3-401593eba46b)
![Quickstart_ Sign and validate a container image _ Notary _ Signing and verifying artifacts  Safeguarding the software delivery security from development to deployment  - Google Chrome 5_11_2023 11_25_27 PM (2)](https://github.com/notaryproject/notaryproject.dev/assets/86047367/84af43f6-d616-4df8-ab0b-a5df826edd44)