### PR TITLE
Footer: Fix alignment of footer items

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -15,7 +15,7 @@
     </div>
   </div>
   <div>
-    <small class="text-white">
+    <small class="row text-white text-center">
       &copy; copyright {{ now.Year }} | All Rights Reserved
     </small>
   </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,6 +1,6 @@
 {{/* notaryproject-docsy file override */ -}}
 <footer class="footer bg-dark flex space-between is-align-items-center is-mobile-responsive">
-  <div class="img-container-sm">
+  <div>
     <a href="{{ .Site.Home.RelPermalink }}">
       {{ $image := resources.Get "icons/logo-dark.png" }}
       <img src="{{ $image.RelPermalink }}" alt="notary logo">


### PR DESCRIPTION
The logo and copyright text on the Notary website footer is misaligned. 

For the logo, it was due to the presence of a class which had different size restrictions. Removal of the said class has no usability impact but leads to better alignment (On both, mobile and desktop).

For the text, it was due to the lack of presence of two style classes.

Before:
![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/d55af9f2-8852-43fc-a2e7-21f0e712c505)

![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/309fb4ba-aebb-4239-8468-80b57c80a0ce)

After:
![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/90003b71-1535-4f36-b0ba-ee5bc03bf958)

![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/08e1436a-e5ce-478f-8125-d66a0a76b8f9)

