### PR TITLE
Navbar: Fix active class not applied on Blog

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -178,9 +178,6 @@ outputs:
 # Site menu (partial -- also see pages with 'menu' in front matter)
 menu:
   main:
-    - name: Blog
-      url: ./blog/
-      weight: -50
     - name: Roadmap
       url: https://github.com/notaryproject/roadmap
       weight: -20

--- a/content/en/blog/_index.md
+++ b/content/en/blog/_index.md
@@ -2,6 +2,10 @@
 title: Blog
 linkTitle: Blog
 description: News, updates, release announcements, and more
+menu:
+  main:
+    name: Blog
+    weight: -50
 # Notes:
 # - Place blog entries under a folder corresponding to the year of publication.
 # - By default the permalink will be /blog/year/filename. If you'd rather have


### PR DESCRIPTION
The "Blog" link on Navbar was not getting the active class due to a misconfiguration in "config.yaml".
This PR fixes that.

Before:
![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/059bd292-db98-4d1b-92b0-10e8c6d4171c)

Now:
![image](https://github.com/notaryproject/notaryproject.dev/assets/34372791/c37843a6-e7d2-4daf-b26b-00483c64c99c)
