### PR TITLE
Grammartical mistake

### DIFF
--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -24,7 +24,7 @@ docker run -d -p 5001:5000 -e REGISTRY_STORAGE_DELETE_ENABLED=true --name regist
 If the host port 5001 is already in use, you can use another host port. 
 {{% /alert %}}
 
-If you want to use Notation with other registries, refer to [registries are compatible with Notary]({{< ref "/docs/faq#what-registries-are-compatible-with-notary" >}}) for more alternatives. See [Authenticate with OCI-compliant registries]({{< ref "/docs/how-to/registry-authentication" >}}) when you log in to another OCI registry.
+If you want to use Notation with other registries, refer to [which registries are compatible with Notary]({{< ref "/docs/faq#what-registries-are-compatible-with-notary" >}}) for more alternatives. See [Authenticate with OCI-compliant registries]({{< ref "/docs/how-to/registry-authentication" >}}) when you log in to another OCI registry.
 
 ## Add an image to the OCI-compatible registry
 


### PR DESCRIPTION
Fixes #231 

spelling mistake in quickstart.md

Improved sentence is `which registries are compatible with Notary`

 
The change from "registries" to "which registries" improves the clarity and readability of the sentence. It specifies that the reader should refer to the list of registries that are compatible with Notary.