### PR TITLE
Each blog card on the homepage is clickable

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -487,6 +487,7 @@ section:nth-of-type(2) {
   box-shadow: 0px 7px 30px rgba(0, 0, 0, 0.2);
   padding: 1.4em 1.8rem;
   font-size: 1.1rem;
+  cursor: pointer;
 }
 
 .verticalCard {
@@ -494,6 +495,7 @@ section:nth-of-type(2) {
   box-shadow: 0px 7px 30px rgba(0, 0, 0, 0.2);
   padding: 1.5em 2.7rem;
   padding-bottom: 3.6rem;
+  cursor: pointer;
 }
 
 .flex-30 {

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -286,7 +286,7 @@ title: Notary Project
 {{% /blocks/lead %}} {{% blocks/lead color="white" %}}
 <h2 class="title">News & Blogs</h2>
 <div class="flex gap-lg is-centered width-70 is-mobile-responsive">
-  <div class="verticalCard flex-30">
+  <div class="verticalCard flex-30" onclick="location.href='https://notaryproject.dev/blog/2023/notary-completes-fuzzing-security-audit/';">
     <div class="img-container-md fullwidth is-centered">
       <img src="notary-fuzz.png" alt="Notary fuzz test" />
     </div>
@@ -307,7 +307,7 @@ title: Notary Project
   <div class="flex-70">
     <div
       class="horizontalCard flex gap-md is-align-items-center is-mobile-responsive"
-    >
+      onclick="location.href='https://notaryproject.dev/blog/2023/announcing-notation-rc3/';">
       <div class="img-container-lg flex-30">
         <img src="logo.svg" alt="notary logo" />
       </div>
@@ -332,3 +332,7 @@ title: Notary Project
   <!-- {{< home/used-by >}} -->
   {{< home/cncf >}}
 </div>
+
+<script>
+
+</script>

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -69,6 +69,10 @@ The following command generates a test key and a self-signed X.509 certificate. 
 notation cert generate-test --default "wabbit-networks.io"
 ```
 
+{{% alert title="Note" color="primary" %}}
+At this time, test key and self-signed certificate files created using `notation cert generate-test` can't be removed using only `notation key delete` and `notation cert delete`. For more details on fully removing the test key and self-signed certificate files, see [Remove the test key and self-signed certificate]({{< ref "/docs/installation/uninstall#remove-the-test-key-and-self-signed-certificate" >}}).
+{{% /alert %}}
+
 Use `notation key ls` to confirm the signing key is correctly configured. Key name with a `*` prefix is the default key.
 
 ```console


### PR DESCRIPTION
fixed #247 

The current behavior is after only clicking to "Learn more" button, we can visit the specific blog. But now after making the overall blog container clickable. We can click anywhere in the blog container to visit the blog.  

