### PR TITLE
added box shadow to navbar

### DIFF
--- a/assets/scss/_styles_project.scss
+++ b/assets/scss/_styles_project.scss
@@ -242,6 +242,10 @@
   color: #000;
 }
 
+.td-navbar-cover{
+  box-shadow: 0px 2px lightgrey;
+}
+
 .td-navbar-cover .nav-link {
      text-shadow:none;
 }

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -69,6 +69,10 @@ The following command generates a test key and a self-signed X.509 certificate. 
 notation cert generate-test --default "wabbit-networks.io"
 ```
 
+{{% alert title="Note" color="primary" %}}
+At this time, test key and self-signed certificate files created using `notation cert generate-test` can't be removed using only `notation key delete` and `notation cert delete`. For more details on fully removing the test key and self-signed certificate files, see [Remove the test key and self-signed certificate]({{< ref "/docs/installation/uninstall#remove-the-test-key-and-self-signed-certificate" >}}).
+{{% /alert %}}
+
 Use `notation key ls` to confirm the signing key is correctly configured. Key name with a `*` prefix is the default key.
 
 ```console


### PR DESCRIPTION
fixed #239 

The box shadow is added to the navbar because the below information does not look differentiate. Here are image references for that. 

<details><summary>Without Box-Shadow</summary>
<p>

<img width="960" alt="Screenshot 2023-05-23 154903" src="https://github.com/notaryproject/notaryproject.dev/assets/91155068/7dd1d54c-939b-4588-aeb3-151222e130d4">

</p>
</details> 

<details><summary>With Box-Shadow</summary>
<p>

<img width="960" alt="Screenshot 2023-05-23 154627" src="https://github.com/notaryproject/notaryproject.dev/assets/91155068/603178b8-1b54-4795-a509-4b75e020937e">


</p>
</details> 
 