### PR TITLE
images/text overlaps with navigation bar & logo fixed

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,6 +1,6 @@
 {{ $cover := .HasShortcode "blocks/cover" }}
 {{ partial "banner.html" . }}
-<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar">
+<nav class="js-navbar-scroll navbar navbar-expand navbar-dark {{ if $cover}} td-navbar-cover {{ end }}flex-column flex-md-row td-navbar navbar-bg-onscroll">
         <a class="navbar-brand" href="{{ .Site.Home.RelPermalink }}">
 		<span class="navbar-logo">{{ if .Site.Params.ui.navbar_logo }}{{ with resources.Get "icons/logo.svg" }}{{ ( . | minify).Content | safeHTML }}{{ end }}{{ end }}</span>
 	</a>


### PR DESCRIPTION
fixed #241 #236 

Page elements overlap with the Notary logo and navigation bar while scrolling. Please take a look at the attached video for reference.

<details><summary>Difficulties encountered when scrolling</summary>
<p>

https://github.com/notaryproject/notaryproject.dev/assets/91155068/5e40b9d2-3d9d-405c-91e5-881b1975857e

</p>
</details> 

<details><summary>Output</summary>
<p>

https://github.com/notaryproject/notaryproject.dev/assets/91155068/6cb517b1-bec4-4a13-9aed-8578a66920af

</p>
</details> 