### PR TITLE
Add Notation interactive tutorial to website

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -34,7 +34,7 @@ title: Notary Project
           Get started
         </button>
       </a>
-      <a href="https://killercoda.com/notaryproject/scenario/notation">
+      <a href="https://killercoda.com/notaryproject/scenario/notation" target="_blank" rel="noopener noreferrer">
         <button class="button is-medium is-dark demo">Try it
           <span></span>
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" style="height: 1rem;">

--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -34,8 +34,14 @@ title: Notary Project
           Get started
         </button>
       </a>
-      <a href="https://github.com/notaryproject/notation">
-        <button class="button is-medium is-dark demo">GitHub</button>
+      <a href="https://killercoda.com/notaryproject/scenario/notation">
+        <button class="button is-medium is-dark demo">Try it
+          <span></span>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="white" style="height: 1rem;">
+          <path fill-rule="evenodd" d="M4.25 5.5a.75.75 0 00-.75.75v8.5c0 .414.336.75.75.75h8.5a.75.75 0 00.75-.75v-4a.75.75 0 011.5 0v4A2.25 2.25 0 0112.75 17h-8.5A2.25 2.25 0 012 14.75v-8.5A2.25 2.25 0 014.25 4h5a.75.75 0 010 1.5h-5z" clip-rule="evenodd" />
+          <path fill-rule="evenodd" d="M6.194 12.753a.75.75 0 001.06.053L16.5 4.44v2.81a.75.75 0 001.5 0v-4.5a.75.75 0 00-.75-.75h-4.5a.75.75 0 000 1.5h2.553l-9.056 8.194a.75.75 0 00-.053 1.06z" clip-rule="evenodd" />
+        </svg>
+        </button>
       </a>
     </div>
   </div>

--- a/content/en/docs/quickstart.md
+++ b/content/en/docs/quickstart.md
@@ -5,6 +5,10 @@ type: docs
 weight: 2
 ---
 
+{{% alert title="Playground" color="info" %}}
+You can also follow this guide on online remote cloud interactive playground on killercoda: https://killercoda.com/notaryproject/scenario/notation
+{{% /alert %}}
+
 ## Prerequisites
 
 Before you begin, you need:


### PR DESCRIPTION
### This PR does the following changes

1. 7cff57998a952b0fa3b2d49d951a78b54f065c46 replaces GitHub button with link to notation scenario and adds SVG icon indicating external link and opens that link in new tab a4687f94c23bedd00927fa64b065a5d3744e394d.


![image](https://github.com/notaryproject/notaryproject.dev/assets/84327775/07139ac9-06ce-4d36-9286-ec0222898ef6)

2. ded32bf6820170b7d908e893707914ea4d7627c5 adds info about online tutorial on `/docs/quickstart`


![image](https://github.com/notaryproject/notaryproject.dev/assets/84327775/fc909ec0-9622-499c-bc2b-0bb7c744a3b2)

---

### Preview changes: 

- https://deploy-preview-273--notarydev.netlify.app/
- https://deploy-preview-273--notarydev.netlify.app/docs/quickstart/
Closes #272 