### PR TITLE
chore: add GitHub action for stale issues and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: "This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days."
+          stale-pr-message: "This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 30 days."
+          close-issue-message: "This issue was closed because it has been stalled for 30 days with no activity."
+          close-pr-message: "This PR was closed because it has been stalled for 30 days with no activity."
+          days-before-issue-stale: 60
+          days-before-pr-stale: 45
+          days-before-issue-close: 30
+          days-before-pr-close: 30


### PR DESCRIPTION
This PR enables the `notaryproject.dev` repo to run stale action at 1:30 every day to label or close stale PRs and issues. See guideline https://github.com/marketplace/actions/close-stale-issues

This is the definition for stale PRs or issues that we discussed during community call and to be updated in [contributing PR](https://github.com/notaryproject/.github/pull/25).

"A stale issue is one that remains inactive or without updates for a period of 60 days. A stale pull request (PR) is one that remains inactive or without updates for a period of 45 days. When an issue or PR becomes stale, it is labelled as `stale`. Normally maintainers will comment on stale issues or PRs to prompt participants to take action. If there is no activity for additional 30 days, this issue or PR will be closed. If an update/comment occur on stale issues or pull requests, the stale label will be removed, and the timer will restart"

