### PR TITLE
chore: add redirect rule to resolve a broken link used by Notation CLI

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,6 @@ command = "npm run build:preview"
 command = "npm run build:production"
 
 [[redirects]]
-  from = "/how-to/*"
-  to = "/user-guides/how-to/"
+  from = "/docs/how-to/*"
+  to = "/docs/user-guides/how-to/*"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,8 @@ command = "npm run build:preview"
 
 [context.production]
 command = "npm run build:production"
+
+[[redirects]]
+  from = "/how-to/*"
+  to = "/user-guides/how-to/"
+  status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,6 @@ command = "npm run build:preview"
 command = "npm run build:production"
 
 [[redirects]]
-  from = "/docs/how-to/*"
-  to = "/docs/user-guides/how-to/*"
+  from = "/docs/how-to/registry-authentication/"
+  to = "/docs/user-guides/how-to/registry-authentication/"
   status = 301


### PR DESCRIPTION
Fix https://github.com/notaryproject/notation/issues/783

How to test:
Access https://deploy-preview-375--notarydev.netlify.app/docs/how-to/registry-authentication/, it will redirect to https://deploy-preview-375--notarydev.netlify.app/docs/user-guides/how-to/registry-authentication/

After merging this PR, it should work and redirect the broken link https://notaryproject.dev/docs/how-to/registry-authentication/ to https://notaryproject.dev/docs/user-guides/how-to/registry-authentication/