### PR TITLE
Added Version control for documentation

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -55,9 +55,12 @@ markup:
 
 params:
   versions:
-    - version: master
+    - version: main
       name: main
       url: "https://notaryproject.dev/"
+    - version: v1.2
+      name: v1.2
+      url: "https://v1-2.notaryproject.dev/"
     - version: v1.1
       name: v1.1
       url: "https://v1-1.notaryproject.dev/"

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 baseURL: https://notaryproject.dev/
+
 enableRobotsTxt: true
 
 theme: [docsy]
@@ -53,6 +54,19 @@ markup:
 # Everything below this are Site Params
 
 params:
+  versions:
+    # In case of adding a new version, eg. v1.1, replace master (v0.1) with v1.1.
+    - version: master
+      name: Master (v0.1)
+      url: "https://notaryproject.dev/docs/"
+
+  version_menu: "v0.1"
+  version_menu_pagelinks: true
+
+  archived_version: true
+  version: "0.1"
+  url_latest_version: "https://your-latest-doc-site.com"
+
   copyright: Notary Project Authors
   description: >-
     A distributed, reliable key-value store for the most critical data of a

--- a/config.yaml
+++ b/config.yaml
@@ -56,9 +56,15 @@ markup:
 params:
   versions:
     - version: master
-      name: Master (v0.1)
-      url: "https://notaryproject.dev/docs/"
-  version_menu: "v0.1"
+      name: main
+      url: "https://notaryproject.dev/"
+    - version: v1.1
+      name: v1.1
+      url: "https://v1-1.notaryproject.dev/"
+    - version: v1.0
+      name: v1.0
+      url: "https://v1-0.notaryproject.dev/"
+  version_menu: "Version"
   version_menu_pagelinks: true
   archived_version: true
   version: "0.1"

--- a/config.yaml
+++ b/config.yaml
@@ -55,17 +55,14 @@ markup:
 
 params:
   versions:
-    # In case of adding a new version, eg. v1.1, replace master (v0.1) with v1.1.
     - version: master
       name: Master (v0.1)
       url: "https://notaryproject.dev/docs/"
-
   version_menu: "v0.1"
   version_menu_pagelinks: true
-
   archived_version: true
   version: "0.1"
-  url_latest_version: "https://your-latest-doc-site.com"
+  url_latest_version: "https://notaryproject.dev/docs/"
 
   copyright: Notary Project Authors
   description: >-

--- a/content/en/docs/user-guides/installation/cli.md
+++ b/content/en/docs/user-guides/installation/cli.md
@@ -2,12 +2,13 @@
 title: Install the notation CLI
 description: Install the notation CLI on Linux, macOS, and Windows
 weight: 1
-cliVer : 1.0.1
+cliVer: 1.0.1
 ---
 
 ## Download and install the CLI for Linux
 
 ### Homebrew
+
 Download the latest stable release of the `notation CLI` on Linux using [Homebrew](https://brew.sh/):
 
 ```console
@@ -15,6 +16,7 @@ brew install notation
 ```
 
 ### Binary download
+
 Download the latest stable release of the notation CLI binary for Linux and checksum file, then verify the integrity of the download.
 
 Set the `NOTATION_VERSION` environment variable to the version of notation you want to download. The latest version is `{{< param cliVer >}}`.
@@ -72,6 +74,7 @@ echo 'export PATH="$PATH:<EXAMPLE_PATH>/notation-cli/"' >> ~/.bashrc
 ## Download and install the CLI for macOS
 
 ### Homebrew
+
 Download the latest stable release of the `notation CLI` on macOS using [Homebrew](https://brew.sh/):
 
 ```console
@@ -79,6 +82,7 @@ brew install notation
 ```
 
 ### Binary download
+
 Download the latest stable release of the notation CLI binary for macOS and checksum file, then verify the integrity of the download.
 
 Set the `NOTATION_VERSION` environment variable to the version of notation you want to download. The latest version is `{{< param cliVer >}}`.
@@ -136,16 +140,19 @@ echo 'export PATH="$PATH:<EXAMPLE_PATH>/notation-cli/"' >> ~/.zshrc
 ## Download and install the CLI for Windows
 
 ### WinGet
+
 Download the latest stable release of the `notation CLI` on Windows using [WinGet (Windows package manager)](https://github.com/microsoft/winget-pkgs):
 
 ```console
 winget install notation -s winget
 ```
+
 ### .exe download
+
 Download the latest stable release of the notation CLI binary for Windows and checksum file:
 
-* [notation_{{< param cliVer >}}_windows_amd64.zip](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation_{{< param cliVer >}}_windows_amd64.zip)
-* [notation_{{< param cliVer >}}_checksums.txt](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation_{{< param cliVer >}}_checksums.txt)
+- [notation_{{< param cliVer >}}_windows_amd64.zip](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation\_{{< param cliVer >}}\_windows_amd64.zip)
+- [notation_{{< param cliVer >}}_checksums.txt](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation\_{{< param cliVer >}}\_checksums.txt)
 
 Use the [Get-FileHash](https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.3) command in powershell to generate the hash of the archive file.
 

--- a/content/en/docs/user-guides/installation/cli.md
+++ b/content/en/docs/user-guides/installation/cli.md
@@ -151,8 +151,8 @@ winget install notation -s winget
 
 Download the latest stable release of the notation CLI binary for Windows and checksum file:
 
-- [notation_{{< param cliVer >}}_windows_amd64.zip](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation\_{{< param cliVer >}}\_windows_amd64.zip)
-- [notation_{{< param cliVer >}}_checksums.txt](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation\_{{< param cliVer >}}\_checksums.txt)
+* [notation_{{< param cliVer >}}_windows_amd64.zip](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation_{{< param cliVer >}}_windows_amd64.zip)
+* [notation_{{< param cliVer >}}_checksums.txt](https://github.com/notaryproject/notation/releases/download/v{{< param cliVer >}}/notation_{{< param cliVer >}}_checksums.txt)
 
 Use the [Get-FileHash](https://learn.microsoft.com/powershell/module/microsoft.powershell.utility/get-filehash?view=powershell-7.3) command in powershell to generate the hash of the archive file.
 

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,2 +1,1 @@
-{{ $latest := site.Params.versions.latest }}
-
+{{ $latest := index $.Site.Params.versions 0 }}

--- a/layouts/index.redirects
+++ b/layouts/index.redirects
@@ -1,1 +1,1 @@
-{{ $latest := index $.Site.Params.versions 0 }}
+{{ $latest := index .Site.Params.versions (sub (len .Site.Params.versions) 1) }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -20,6 +20,18 @@
 				<a class="nav-link{{if $active }} active{{end}}" href="{{ with .Page }}{{ .RelPermalink }}{{ else }}{{ .URL | relLangURL }}{{ end }}" {{ if ne $url.Host $baseurl.Host }}target="_blank" {{ end }}>{{ with .Pre}}{{ $pre }}{{ end }}<span{{if $active }} class="active"{{end}}>{{ .Name }}</span>{{ with .Post}}{{ $post }}{{ end }}</a>
 			</li>
 			{{ end }}
+			{{ if  .Site.Params.versions }}
+			<li class="nav-item dropdown mr-4 d-none d-lg-block">
+				<a class="nav-link dropdown-toggle" href="#" id="versionDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				  {{ $.Site.Params.version_menu }}
+				</a>
+				<div class="dropdown-menu" aria-labelledby="versionDropdown">
+				  {{ range $.Site.Params.versions }}
+					<a class="dropdown-item" href="{{ .url }}">{{ .name }}</a>
+				  {{ end }}
+				</div>
+			  </li>
+			{{ end }}
             <div class="flex gap-md nav-item mr-4 mb-2 mb-lg-0">
                 <div class="img-container-xxsm">
                     <a class="nav-link" href="{{ .Site.Params.navbar.logos.github.url }}">
@@ -40,11 +52,6 @@
                     </a>
                 </div>
             </div>
-			{{ if  .Site.Params.versions }}
-			<li class="nav-item dropdown mr-4 d-none d-lg-block">
-				{{ partial "navbar-version-selector.html" . }}
-			</li>
-			{{ end }}
 			{{ if  (gt (len .Site.Home.Translations) 0) }}
 			<li class="nav-item dropdown mr-4 d-none d-lg-block">
 				{{ partial "navbar-lang-selector.html" . }}

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -22,7 +22,7 @@
 			{{ end }}
 			{{ if  .Site.Params.versions }}
 			<li class="nav-item dropdown mr-4 d-none d-lg-block">
-				<a class="nav-link dropdown-toggle" href="#" id="versionDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+				<a class="nav-link dropdown-toggle" id="versionDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 				  {{ $.Site.Params.version_menu }}
 				</a>
 				<div class="dropdown-menu" aria-labelledby="versionDropdown">


### PR DESCRIPTION
Added version control for documentation. Currently, the name of the current version in the drop-down is set as `Master (v0.1)`, and the version menu is named `version_menu: "v0.1"`. Ensure to edit the names accordingly when updating to a new version.

Fixes: #370 #350 