### PR TITLE
chore: update Notation CLI version to v1.1.2

### DIFF
--- a/content/en/docs/user-guides/installation/cli.md
+++ b/content/en/docs/user-guides/installation/cli.md
@@ -2,7 +2,7 @@
 title: Install the notation CLI
 description: Install the notation CLI on Linux, macOS, and Windows
 weight: 1
-cliVer : 1.1.1
+cliVer : 1.1.2
 ---
 
 ## Download and install the CLI for Linux

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,6 +1,6 @@
 <section class="news is-medium flex justify-center">
     <p class="is-size-3-mobile">
-      <a href="https://github.com/notaryproject/notation/releases/tag/v1.1.1" class="banner-link">Notation v1.1.1 is available</a>
+      <a href="https://github.com/notaryproject/notation/releases/tag/v1.1.2" class="banner-link">Notation v1.1.2 is available</a>
       <span>
         {{ $rocketIcon := resources.Get "icons/rocket-icon.svg" }}
         <img


### PR DESCRIPTION
Update Notation CLI version to v1.1.2 due to v1.1.2 has been released https://github.com/notaryproject/notation/releases/tag/v1.1.2