### PR TITLE
Add Scarf documentation pixel to footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -4,6 +4,7 @@
     <a href="{{ .Site.Home.RelPermalink }}">
       {{ $image := resources.Get "icons/logo-dark.png" }}
       <img src="{{ $image.RelPermalink }}" alt="notary logo">
+      <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=eae5eb69-4ef7-47de-a5c7-eb08f9f16e59" />
     </a>
   </div>
   <div class="row text-center text-white small">


### PR DESCRIPTION
Scarf and the Notary Project have been in direct discussions, and Notary project maintainers have requested that a Scarf tracking pixel is added to the Notary documentation. This tracking pixel is fully GDPR-compliant, cookieless, and does not contain JavaScript. Further documentation surrounding this pixel can be found here: https://docs.scarf.sh/web-traffic/. 

@FeynmanZhou