### PR TITLE
docs: update installation guide to v1.3.1 and remove version info from plugin page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,9 @@ params:
     - version: main
       name: main
       url: "https://notaryproject.dev/"
+    - version: v2.0.0-alpha.1
+      name: v2.0.0-alpha.1
+      url: "https://v2-0.notaryproject.dev/"
     - version: v1.3
       name: v1.3
       url: "https://v1-3.notaryproject.dev/"

--- a/config.yaml
+++ b/config.yaml
@@ -58,6 +58,9 @@ params:
     - version: main
       name: main
       url: "https://notaryproject.dev/"
+    - version: v1.3
+      name: v1.3
+      url: "https://v1-3.notaryproject.dev/"
     - version: v1.2
       name: v1.2
       url: "https://v1-2.notaryproject.dev/"

--- a/config.yaml
+++ b/config.yaml
@@ -58,8 +58,8 @@ params:
     - version: main
       name: main
       url: "https://notaryproject.dev/"
-    - version: v2.0.0-alpha.1
-      name: v2.0.0-alpha.1
+    - version: v2.0-alpha.1
+      name: v2.0-alpha.1
       url: "https://v2-0.notaryproject.dev/"
     - version: v1.3
       name: v1.3

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -45,43 +45,43 @@ Successfully installed plugin com.amazonaws.signer.notation.plugin, version 1.0.
 ```
 Upon successful execution, the plugin is copied to Notation's plugin directory.
 
-## Install Notation Azure Key Vault Plugin (v1.0.2)
+## Install Notation Azure Key Vault Plugin
 
 To find out more about the Azure Key Vault Plugin, please refer to this [GitHub repository](https://github.com/Azure/notation-azure-kv).
 
 ### Install from URL:
 
 ```console
-notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_1.0.2_linux_amd64.tar.gz --sha256sum f2b2e131a435b6a9742c202237b9aceda81859e6d4bd6242c2568ba556cee20e
+notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/<$VERSION_AKV_PLUGIN>/notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz --sha256sum <$SHA256_SUM_AKV_PLUGIN>
 
-Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_1.0.2_linux_amd64.tar.gz
+Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz
 Download completed
-Successfully installed plugin azure-kv, version 1.0.2
+Successfully installed plugin azure-kv, version <$VERSION_AKV_PLUGIN>
 ```
 
 ### Install from local file:
 
 ```console
-notation plugin install --file notation-azure-kv_1.0.2_linux_amd64.tar.gz
-Successfully installed plugin azure-kv, version 1.0.2
+notation plugin install --file notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz
+Successfully installed plugin azure-kv, version <$VERSION_AKV_PLUGIN>
 ```
 
-## Install Notation Venafi Plugin (v0.3.2)
+## Install Notation Venafi Plugin (<$VERSION_Venafi_PLUGIN>)
 
 To find out more about the Venafi Plugin, please refer to this [GitHub repository](https://github.com/Venafi/notation-venafi-csp).
 
 ### Install from URL:
 
 ```console
-notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/v0.3.2/notation-venafi-csp-linux-amd64.tar.gz --sha256sum f9e52bce64c8b6dcc9a7c8d5e204b911ba29a06fb8c35cefe9fd21cc5693a6d1
-Successfully installed plugin venafi-csp, version 0.3.2-release
+notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/<$VERSION_Venafi_PLUGIN>/notation-venafi-csp-linux-amd64.tar.gz --sha256sum <$SHA256SUM_VENAFI_PLUGIN>
+Successfully installed plugin venafi-csp, version <$VERSION_VENAFI_PLUGIN>
 ```
 
 ### Install from local file:
 
 ```console
 notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
-Successfully installed plugin venafi-csp, version 0.3.2-release
+Successfully installed plugin venafi-csp, version <$VERSION_Venafi_PLUGIN>
 ```
 
 To confirm you plugin is installed, run `notation plugin list`. For example:

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -73,7 +73,7 @@ To find out more about the Venafi Plugin, please refer to this [GitHub repositor
 ### Install from URL:
 
 ```console
-$ notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/${VERSION_Venafi_PLUGIN}/notation-venafi-csp-linux-amd64.tar.gz --sha256sum ${SHA256SUM_VENAFI_PLUGIN}
+$ notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/${VERSION_VENAFI_PLUGIN}/notation-venafi-csp-linux-amd64.tar.gz --sha256sum ${SHA256SUM_VENAFI_PLUGIN}
 Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 ```
 

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -54,7 +54,7 @@ To find out more about the Azure Key Vault Plugin, please refer to this [GitHub 
 ```console
 $ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/{VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256_SUM_AKV_PLUGIN}
 
-Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
+Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
 Download completed
 Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
 ```

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -38,9 +38,9 @@ To find out more about the AWS Signer plugin, please refer to their official [do
 ### Install from file system
 
 ```console
-wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip
+$ wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip
 
-notation plugin install --file notation-aws-signer-plugin.zip
+$ notation plugin install --file notation-aws-signer-plugin.zip
 Successfully installed plugin com.amazonaws.signer.notation.plugin, version 1.0.298
 ```
 Upon successful execution, the plugin is copied to Notation's plugin directory.
@@ -52,36 +52,36 @@ To find out more about the Azure Key Vault Plugin, please refer to this [GitHub 
 ### Install from URL:
 
 ```console
-notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/<$VERSION_AKV_PLUGIN>/notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz --sha256sum <$SHA256_SUM_AKV_PLUGIN>
+$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/{VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256_SUM_AKV_PLUGIN}
 
-Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz
+Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/v1.0.2/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
 Download completed
-Successfully installed plugin azure-kv, version <$VERSION_AKV_PLUGIN>
+Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
 ```
 
 ### Install from local file:
 
 ```console
-notation plugin install --file notation-azure-kv_<$VERSION_AKV_PLUGIN>_linux_amd64.tar.gz
-Successfully installed plugin azure-kv, version <$VERSION_AKV_PLUGIN>
+$ notation plugin install --file notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
+Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
 ```
 
-## Install Notation Venafi Plugin (<$VERSION_Venafi_PLUGIN>)
+## Install Notation Venafi Plugin
 
 To find out more about the Venafi Plugin, please refer to this [GitHub repository](https://github.com/Venafi/notation-venafi-csp).
 
 ### Install from URL:
 
 ```console
-notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/<$VERSION_Venafi_PLUGIN>/notation-venafi-csp-linux-amd64.tar.gz --sha256sum <$SHA256SUM_VENAFI_PLUGIN>
-Successfully installed plugin venafi-csp, version <$VERSION_VENAFI_PLUGIN>
+$ notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/${VERSION_Venafi_PLUGIN}/notation-venafi-csp-linux-amd64.tar.gz --sha256sum ${SHA256SUM_VENAFI_PLUGIN}
+Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 ```
 
 ### Install from local file:
 
 ```console
-notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
-Successfully installed plugin venafi-csp, version <$VERSION_Venafi_PLUGIN>
+$ notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
+Successfully installed plugin venafi-csp, version ${VERSION_Venafi_PLUGIN}
 ```
 
 To confirm you plugin is installed, run `notation plugin list`. For example:
@@ -90,7 +90,7 @@ To confirm you plugin is installed, run `notation plugin list`. For example:
 notation plugin list
 ```
 
-Confirm the plugin is listed in the output. For example:
+Confirm the plugin is listed in the output. A sample output is as follows:
 
 ```console
 $ notation plugin list

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -47,9 +47,12 @@ wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aw
 notation plugin install --file notation-aws-signer-plugin.zip
 ```
 
+Here is the sample output:
+
 ```console
 Successfully installed plugin com.amazonaws.signer.notation.plugin, version 1.0.298
 ```
+
 Upon successful execution, the plugin is copied to Notation's plugin directory.
 
 ## Install Notation Azure Key Vault Plugin

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -19,6 +19,8 @@ Before creating the `{plugin-name}` directory, confirm you are using a name that
 
 ## Usage
 
+Remember to replace the variables below with the desired plugin version and checksum.
+
 ### Install a plugin from file system:
 
 `notation plugin install --file <file_path>`

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -81,7 +81,7 @@ Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 
 ```console
 $ notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
-Successfully installed plugin venafi-csp, version ${VERSION_Venafi_PLUGIN}
+Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 ```
 
 To confirm you plugin is installed, run `notation plugin list`. For example:

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -52,7 +52,7 @@ To find out more about the Azure Key Vault Plugin, please refer to this [GitHub 
 ### Install from URL:
 
 ```console
-$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/{VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256_SUM_AKV_PLUGIN}
+$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256_SUM_AKV_PLUGIN}
 
 Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
 Download completed

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -52,7 +52,7 @@ To find out more about the Azure Key Vault Plugin, please refer to this [GitHub 
 ### Install from URL:
 
 ```console
-$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256_SUM_AKV_PLUGIN}
+$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256SUM_AKV_PLUGIN}
 
 Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
 Download completed

--- a/content/en/docs/user-guides/how-to/plugin-management.md
+++ b/content/en/docs/user-guides/how-to/plugin-management.md
@@ -40,9 +40,14 @@ To find out more about the AWS Signer plugin, please refer to their official [do
 ### Install from file system
 
 ```console
-$ wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip
+wget https://d2hvyiie56hcat.cloudfront.net/linux/amd64/plugin/latest/notation-aws-signer-plugin.zip
+```
 
-$ notation plugin install --file notation-aws-signer-plugin.zip
+```console
+notation plugin install --file notation-aws-signer-plugin.zip
+```
+
+```console
 Successfully installed plugin com.amazonaws.signer.notation.plugin, version 1.0.298
 ```
 Upon successful execution, the plugin is copied to Notation's plugin directory.
@@ -54,8 +59,12 @@ To find out more about the Azure Key Vault Plugin, please refer to this [GitHub 
 ### Install from URL:
 
 ```console
-$ notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256SUM_AKV_PLUGIN}
+notation plugin install --url https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz --sha256sum ${SHA256SUM_AKV_PLUGIN}
+```
 
+Here is the sample output:
+
+```console
 Downloading plugin from https://github.com/Azure/notation-azure-kv/releases/download/${VERSION_AKV_PLUGIN}/notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
 Download completed
 Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
@@ -64,7 +73,12 @@ Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
 ### Install from local file:
 
 ```console
-$ notation plugin install --file notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
+notation plugin install --file notation-azure-kv_${VERSION_AKV_PLUGIN}_linux_amd64.tar.gz
+```
+
+Here is the sample output:
+
+```
 Successfully installed plugin azure-kv, version ${VERSION_AKV_PLUGIN}
 ```
 
@@ -75,14 +89,24 @@ To find out more about the Venafi Plugin, please refer to this [GitHub repositor
 ### Install from URL:
 
 ```console
-$ notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/${VERSION_VENAFI_PLUGIN}/notation-venafi-csp-linux-amd64.tar.gz --sha256sum ${SHA256SUM_VENAFI_PLUGIN}
+notation plugin install --url https://github.com/Venafi/notation-venafi-csp/releases/download/${VERSION_VENAFI_PLUGIN}/notation-venafi-csp-linux-amd64.tar.gz --sha256sum ${SHA256SUM_VENAFI_PLUGIN}
+```
+
+Here is the sample output:
+
+```console
 Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 ```
 
 ### Install from local file:
 
 ```console
-$ notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
+notation plugin install --file notation-venafi-csp-linux-amd64.tar.gz
+```
+
+Here is the sample output:
+
+```console
 Successfully installed plugin venafi-csp, version ${VERSION_VENAFI_PLUGIN}
 ```
 
@@ -95,7 +119,12 @@ notation plugin list
 Confirm the plugin is listed in the output. A sample output is as follows:
 
 ```console
-$ notation plugin list
+notation plugin list
+```
+
+Here is the sample output:
+
+```
 NAME                                 DESCRIPTION                                           VERSION          CAPABILITIES                                                             ERROR
 
 

--- a/content/en/docs/user-guides/installation/cli.md
+++ b/content/en/docs/user-guides/installation/cli.md
@@ -2,7 +2,7 @@
 title: Install the notation CLI
 description: Install the notation CLI on Linux, macOS, and Windows
 weight: 1
-cliVer : 1.3.0
+cliVer : 1.3.1
 ---
 
 ## Download and install the CLI for Linux

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,6 +1,6 @@
 <section class="news is-medium flex justify-center">
     <p class="is-size-3-mobile">
-      <a href="https://github.com/notaryproject/notation/releases/tag/v1.3.0" class="banner-link">Notation v1.3.0 is available</a>
+      <a href="https://github.com/notaryproject/notation/releases/tag/v2.0.0-alpha.1" class="banner-link">Notation v2.0.0-alpha.1 is available</a>
       <span>
         {{ $rocketIcon := resources.Get "icons/rocket-icon.svg" }}
         <img
@@ -9,7 +9,7 @@
         alt="star icon"
         /></span>
         
-          <b>Notation is now GA and considered ready for production environments.</b>
+          <b>Try the latest release to experience signing and verifying arbitrary blob files.</b>
         
   </p>
 </section>


### PR DESCRIPTION
This PR updates the installation guide to v1.3.1 and remove version info from plugin page. It's had to maintain version info for each plugin on notary project website so we should use an variable.