### PR TITLE
chore: add a redirect rule to mitigate a broken link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,10 +7,10 @@ command = "npm run build:production"
 
 [[redirects]]
   from = "/docs/how-to/registry-authentication/"
-  to = "/docs/installation/cli/"
+  to = "/docs/user-guides/how-to/registry-authentication/"
   status = 301
 
 [[redirects]]
-  from = "/docs/how-to/registry-authentication/"
+  from = "/docs/installation/cli/"
   to = "/docs/user-guides/installation/cli/"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,5 +7,10 @@ command = "npm run build:production"
 
 [[redirects]]
   from = "/docs/how-to/registry-authentication/"
-  to = "/docs/user-guides/how-to/registry-authentication/"
+  to = "/docs/installation/cli/"
+  status = 301
+
+[[redirects]]
+  from = "/docs/how-to/registry-authentication/"
+  to = "/docs/user-guides/installation/cli/"
   status = 301


### PR DESCRIPTION
Note that the installation link has been moved from https://notaryproject.dev/docs/installation/cli/ to https://notaryproject.dev/docs/user-guides/installation/cli/. This PR adds a redirect rule to mitigate the broken link.